### PR TITLE
Integrate ApolloClient and query some sample data

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_ENDPOINT=https://api.graph.cool/simple/v1/cjbd8uc5i09x601029f77ofe4

--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "private": true,
   "dependencies": {
     "antd": "^3.0.3",
+    "apollo-client-preset": "^1.0.6",
+    "graphql": "^0.12.3",
+    "graphql-tag": "^2.6.1",
     "grid-styled": "^2.0.0-11",
     "react": "^16.2.0",
+    "react-apollo": "^2.0.4",
     "react-dom": "^16.2.0",
     "react-router-dom": "^4.2.2",
     "recompose": "^0.26.0",
@@ -25,7 +29,11 @@
     "react-scripts": "1.0.17"
   },
   "lint-staged": {
-    "src/**/*.{js,jsx,json,css}": ["prettier", "eslint --fix", "git add"]
+    "src/**/*.{js,jsx,json,css}": [
+      "prettier",
+      "eslint --fix",
+      "git add"
+    ]
   },
   "scripts": {
     "precommit": "lint-staged",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,22 +1,26 @@
 // @flow
 import React from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { ApolloProvider } from 'react-apollo';
 
 import Layout from './Layout';
 import Main from './Main';
 import Footer from './Footer';
 import Header from './Header';
+import client from '../util/client';
 
 const App = () => (
-  <Layout>
-    <Header />
-    <Router>
-      <div>
-        <Route exact path="/" component={Main} />
-      </div>
-    </Router>
-    <Footer />
-  </Layout>
+  <ApolloProvider client={client}>
+    <Layout>
+      <Header />
+      <Router>
+        <div>
+          <Route exact path="/" component={Main} />
+        </div>
+      </Router>
+      <Footer />
+    </Layout>
+  </ApolloProvider>
 );
 
 export default App;

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -11,10 +11,15 @@ type Grid = {|
   column: number,
 |};
 
+// More info to be added, and probably should be importing type from somewhere else.
+type User = {|
+  username: string,
+|};
+
 export type SubmissionInfo = {
   title: string,
   url: string,
-  submitter: string,
+  author: User,
   comments: Array<{}>,
 };
 
@@ -34,13 +39,13 @@ type Props = {|
 export const Submission = ({
   title,
   url,
-  submitter,
+  author,
   comments,
 }: SubmissionInfo) => (
   <Item actions={[<a key="comment">comment</a>, <a key="flag">flag</a>]}>
     <Item.Meta
       title={<a href={url}>{title}</a>}
-      description={`${submitter} | ${comments.length} comments`}
+      description={`${author.username} | ${comments.length} comments`}
     />
   </Item>
 );

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,30 +1,56 @@
 // @flow
 import React from 'react';
+import { graphql } from 'react-apollo';
+import { compose, branch, renderComponent } from 'recompose';
+import gql from 'graphql-tag';
 
 import List, { type SubmissionInfo } from './List';
 import { Box } from './Layout';
 
-const fakeData: Array<SubmissionInfo> = [
-  {
-    title: 'The Criminal Underworld Is Dropping Bitcoin for Another Currency',
-    url:
-      'https://www.bloomberg.com/news/articles/2018-01-02/criminal-underworld-is-dropping-bitcoin-for-another-currency',
-    submitter: 'fragosti',
-    comments: [],
-  },
-  {
-    title: 'Bitcoin Is The MySpace Of The Cryptocurrency World (Part 1)',
-    url:
-      'https://seekingalpha.com/article/4135035-bitcoin-myspace-cryptocurrency-world-part-1',
-    submitter: 'rgmvisser',
-    comments: [],
-  },
-];
+type Props = {|
+  submissions: Array<SubmissionInfo>,
+|};
 
-const Main = () => (
+// Stateless component for loading state (to avoid if-statement within Main component)
+const MainLoading = () => <Box mx={2}> ...Loading </Box>;
+
+const Main = ({ submissions }: Props) => (
   <Box mx={2}>
-    <List dataSource={fakeData} />
+    <List dataSource={submissions} />
   </Box>
 );
 
-export default Main;
+// The AllPosts graphql query
+const AllPosts = gql`
+  query AllPosts {
+    allPosts {
+      id
+      title
+      url
+      author {
+        username
+      }
+      comments {
+        id
+      }
+    }
+  }
+`;
+
+// graphql(Query) returns a Higher Order Component that injects the result of Query into the Component
+// to which it is applied.
+// Takes an options argument.
+const withData = graphql(AllPosts, {
+  props: ({ data: { loading, allPosts } }) => ({
+    isLoading: loading,
+    submissions: allPosts,
+  }),
+});
+
+// Display the MainLoading component when isLoading is true.
+const displayLoadingState = branch(
+  ({ isLoading }) => isLoading,
+  renderComponent(MainLoading)
+);
+
+export default compose(withData, displayLoadingState)(Main);

--- a/src/util/client.js
+++ b/src/util/client.js
@@ -1,0 +1,10 @@
+import { ApolloClient } from 'apollo-client';
+import { HttpLink } from 'apollo-link-http';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+
+const client = new ApolloClient({
+  link: new HttpLink({ uri: process.env.REACT_APP_API_ENDPOINT }),
+  cache: new InMemoryCache(),
+});
+
+export default client;


### PR DESCRIPTION
I installed ApolloClient and am querying some posts using `AllPosts` query from the API and displaying them.

Used some recompose utilities to avoid creating stateful component as seen in [this post](https://dev-blog.apollodata.com/simplify-your-react-components-with-apollo-and-recompose-8b9e302dea51?&_ga=2.87585624.1977193068.1515381629-889404319.1515381629).

Used some of apollo client query options to change the shape of the data being returned [as seen here](https://www.apollographql.com/docs/react/basics/queries.html#graphql-props-option)