### PR TITLE
update client to still be able to make comments without specifying th…

### DIFF
--- a/src/components/CreateComment.js
+++ b/src/components/CreateComment.js
@@ -63,8 +63,7 @@ const CREATE_COMMENT_MUTATION = gql`
   mutation CreateComment($content: String!, $postId: ID!) {
     createComment(
       content: $content,
-      postId: $postId, 
-      directParentType: POST
+      postId: $postId,
     ) {
       id
     }


### PR DESCRIPTION
The parent type is now inferred on the server side based on if the client passes a parent comment id. This update makes sure that the client doesn't break and that comments can still be made.

Note: must be landed alongside with https://github.com/cryptoinsomnia/prisma-api/pull/15.

Test plan:
can still make comments...
<img width="509" alt="screen shot 2018-04-03 at 8 32 24 am" src="https://user-images.githubusercontent.com/5409341/38259324-904e4b6e-3719-11e8-910f-e9c3196a6dd1.png">
