### PR TITLE
Fix infinite loading if validation fails

### DIFF
--- a/src/components/CreatePost.js
+++ b/src/components/CreatePost.js
@@ -46,12 +46,12 @@ class CreatePost extends Component<Props, State> {
         this.props
           .createPost({ variables: value })
           .then(({ data }) => {
-            this.setState({ didError: false }, () => {
+            this.setState({ didError: false, isLoading: false }, () => {
               this.props.history.push(`/post/${data.createPost.id}`);
             });
           })
           .catch(() => {
-            this.setState({ didError: true });
+            this.setState({ didError: true, isLoading: false });
           });
       } else {
         this.setState({ isLoading: false });


### PR DESCRIPTION
This fixes a problem where we show the loading spinner indefinitely if the form validation fails. 

There are still some annoying validation things having to do with the url field and the description field but that will have to wait.